### PR TITLE
Suggestion for "Modify config to use IPv6 listen_addr by default" PR 

### DIFF
--- a/zebra-network/src/config.rs
+++ b/zebra-network/src/config.rs
@@ -62,9 +62,9 @@ pub struct Config {
     /// `address` can be an IP address or a DNS name. DNS names are
     /// only resolved once, when Zebra starts up.
     ///
-    /// By default, Zebra listenes on '[::]' (all IPv6 and IPv4 addresses).
+    /// By default, Zebra listens on '[::]' (all IPv6 and IPv4 addresses).
     /// This enables dual-stack support, accepting both IPv4 and IPv6 connections.
-    /// 
+    ///
     /// If a specific listener address is configured, Zebra will advertise
     /// it to other nodes. But by default, Zebra uses an unspecified address
     /// ("\[::\]:port"), which is not advertised to other nodes.

--- a/zebra-network/src/config/tests/vectors.rs
+++ b/zebra-network/src/config/tests/vectors.rs
@@ -26,9 +26,12 @@ fn parse_config_listen_addr() {
         ("listen_addr = '[::]'", "[::]:8233"),
         ("listen_addr = '[::]:9999'", "[::]:9999"),
         ("listen_addr = '[::]'\nnetwork = 'Testnet'", "[::]:18233"),
-        ("listen_addr = '[::]:8233'\nnetwork = 'Testnet'", "[::]:8233"),
+        (
+            "listen_addr = '[::]:8233'\nnetwork = 'Testnet'",
+            "[::]:8233",
+        ),
         ("listen_addr = '[::1]:8233'", "[::1]:8233"),
-        ("listen_addr = '[2001:db8::1]:8233'", "[2001:db8::1]:8233")
+        ("listen_addr = '[2001:db8::1]:8233'", "[2001:db8::1]:8233"),
     ];
 
     for (config, value) in fixtures {

--- a/zebrad/tests/common/configs/v2.4.0.toml
+++ b/zebrad/tests/common/configs/v2.4.0.toml
@@ -1,0 +1,86 @@
+# Default configuration for zebrad.
+#
+# This file can be used as a skeleton for custom configs.
+#
+# Unspecified fields use default values. Optional fields are Some(field) if the
+# field is present and None if it is absent.
+#
+# This file is generated as an example using zebrad's current defaults.
+# You should set only the config options you want to keep, and delete the rest.
+# Only a subset of fields are present in the skeleton, since optional values
+# whose default is None are omitted.
+#
+# The config format (including a complete list of sections and fields) is
+# documented here:
+# https://docs.rs/zebrad/latest/zebrad/config/struct.ZebradConfig.html
+#
+# zebrad attempts to load configs in the following order:
+#
+# 1. The -c flag on the command line, e.g., `zebrad -c myconfig.toml start`;
+# 2. The file `zebrad.toml` in the users's preference directory (platform-dependent);
+# 3. The default config.
+#
+# The user's preference directory and the default path to the `zebrad` config are platform dependent,
+# based on `dirs::preference_dir`, see https://docs.rs/dirs/latest/dirs/fn.preference_dir.html :
+#
+# | Platform | Value                                 | Example                                        |
+# | -------- | ------------------------------------- | ---------------------------------------------- |
+# | Linux    | `$XDG_CONFIG_HOME` or `$HOME/.config` | `/home/alice/.config/zebrad.toml`              |
+# | macOS    | `$HOME/Library/Preferences`           | `/Users/Alice/Library/Preferences/zebrad.toml` |
+# | Windows  | `{FOLDERID_RoamingAppData}`           | `C:\Users\Alice\AppData\Local\zebrad.toml`     |
+
+[consensus]
+checkpoint_sync = true
+
+[mempool]
+eviction_memory_time = "1h"
+tx_cost_limit = 80000000
+
+[metrics]
+
+[mining]
+debug_like_zcashd = true
+internal_miner = false
+
+[network]
+cache_dir = true
+crawl_new_peer_interval = "1m 1s"
+initial_mainnet_peers = [
+    "dnsseed.z.cash:8233",
+    "dnsseed.str4d.xyz:8233",
+    "mainnet.seeder.zfnd.org:8233",
+    "mainnet.is.yolo.money:8233",
+]
+initial_testnet_peers = [
+    "dnsseed.testnet.z.cash:18233",
+    "testnet.seeder.zfnd.org:18233",
+    "testnet.is.yolo.money:18233",
+]
+listen_addr = "[::]:8233"
+max_connections_per_ip = 1
+network = "Mainnet"
+peerset_initial_target_size = 25
+
+[rpc]
+cookie_dir = "cache_dir"
+debug_force_finished_sync = false
+enable_cookie_auth = true
+parallel_cpu_threads = 0
+
+[state]
+cache_dir = "cache_dir"
+delete_old_database = true
+ephemeral = false
+
+[sync]
+checkpoint_verify_concurrency_limit = 1000
+download_concurrency_limit = 50
+full_verify_concurrency_limit = 20
+parallel_cpu_threads = 0
+
+[tracing]
+buffer_limit = 128000
+force_use_color = false
+use_color = true
+use_journald = false
+


### PR DESCRIPTION
## Motivation

Suggestion for https://github.com/ZcashFoundation/zebra/pull/9609

The `config_tests` is failing. Cargo fmt also failing.

## Solution

- Add future config for `config_tests` to pass.
- Apply rust format.
- Fix codepsell lint
